### PR TITLE
Implement Default for MapWithDict, MapWithDictBitpacked, Set

### DIFF
--- a/src/map_with_dict.rs
+++ b/src/map_with_dict.rs
@@ -265,6 +265,17 @@ where
     }
 }
 
+impl<K, V> Default for MapWithDict<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Eq + Clone + Hash,
+{
+    fn default() -> Self {
+        // This will never panic when constructing from an empty HashMap
+        Self::try_from(HashMap::default()).unwrap()
+    }
+}
+
 /// Implement `get` for `Archived` version of `MapWithDict` if feature is enabled
 #[cfg(feature = "rkyv_derive")]
 impl<K, V, const B: usize, const S: usize, ST, H> ArchivedMapWithDict<K, V, B, S, ST, H>
@@ -375,6 +386,10 @@ mod tests {
 
     #[test]
     fn test_map_with_dict() {
+        // Create an empty default map
+        let map: MapWithDict<usize, usize> = Default::default();
+        assert!(map.is_empty());
+
         // Collect original key-value pairs directly into a HashMap
         let original_map = gen_map(1000);
 

--- a/src/map_with_dict_bitpacked.rs
+++ b/src/map_with_dict_bitpacked.rs
@@ -298,6 +298,16 @@ where
     }
 }
 
+impl<K> Default for MapWithDictBitpacked<K>
+where
+    K: PartialEq + Hash + Clone,
+{
+    fn default() -> Self {
+        // This will never panic when constructing from an empty HashMap
+        Self::try_from(HashMap::default()).unwrap()
+    }
+}
+
 /// Number of values bit-packed in one batch
 const VALUES_BLOCK_LEN: usize = BitPacker1x::BLOCK_LEN;
 
@@ -496,6 +506,10 @@ mod tests {
 
     #[test]
     fn test_map_with_dict_bitpacked() {
+        // Create an empty default map
+        let map: MapWithDictBitpacked<usize> = Default::default();
+        assert!(map.is_empty());
+
         let items_num = 1000;
         let values_num = 10;
         let original_map = gen_map(items_num, values_num);

--- a/src/set.rs
+++ b/src/set.rs
@@ -168,6 +168,16 @@ where
     }
 }
 
+impl<K> Default for Set<K>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        // This will never panic when constructing from an empty HashSet
+        Self::try_from(HashSet::default()).unwrap()
+    }
+}
+
 /// Implement `contains` for `Archived` version of `Set` if feature is enabled
 #[cfg(feature = "rkyv_derive")]
 impl<K, const B: usize, const S: usize, ST, H> ArchivedSet<K, B, S, ST, H>
@@ -221,6 +231,10 @@ mod tests {
 
     #[test]
     fn test_set_with_hashset() {
+        // Create an empty default set
+        let set: Set<usize> = Default::default();
+        assert!(set.is_empty());
+
         // Collect original key-value pairs directly into a HashSet
         let original_set = gen_set(1000);
 


### PR DESCRIPTION
* Useful in tests.
* Internally, these implementations use `Self::try_from(...).unwrap()`
* There are no concerns about panics, however, because `try_from` only errors on complex inputs--never on empty ones.